### PR TITLE
Mass cleanup part 2: test, test, test!

### DIFF
--- a/src/randomreverser/RandomReverser.java
+++ b/src/randomreverser/RandomReverser.java
@@ -119,7 +119,7 @@ public class RandomReverser {
         if(verbose)
             System.out.println("Reducing:\n"+scaledLattice.toPrettyString());
 
-        BigMatrix transformations = new BigMatrix.Factory().identityMatrix(dimensions);
+        BigMatrix transformations = BigMatrix.identityMatrix(dimensions);
         BigMatrix result = LLL.reduce(scaledLattice, params, transformations);
         //System.out.println("found:\n" + transformations.multiply(unscaledLattice).toPrettyString());
 
@@ -129,7 +129,7 @@ public class RandomReverser {
             //System.out.println("Found Reduced Basis:\n" + result.multiply(scales.inverse()).toPrettyString());
         }
         //Matrix m = new Matrix.Factory().fromBigMatrix(result.multiply(scales.inverse()));
-        lattice = new Matrix.Factory().fromBigMatrix(transformations.multiply(unscaledLattice));
+        lattice = Matrix.fromBigMatrix(transformations.multiply(unscaledLattice));
     }
 
     private void addMeasuredSeed(long min, long max) {
@@ -146,7 +146,7 @@ public class RandomReverser {
 
     public void addNextIntCall(int n, int min, int max) {
         if ((n & (-n)) == n) {// if n is a power of 2
-            int log = Mth.countTrailingZeroes(n);
+            int log = Long.numberOfTrailingZeros(n);
             addMeasuredSeed(min * (1L << (48 - log)), (max+1) * (1L << (48 - log)) - 1);
         }
         else {

--- a/src/randomreverser/math/component/AugmentedMatrix.java
+++ b/src/randomreverser/math/component/AugmentedMatrix.java
@@ -37,16 +37,16 @@ public class AugmentedMatrix {
 
 	@Override
 	public String toString() {
-		return StringUtils.tableToString(Math.max(base.getHeight(), extra.getHeight()), base.getWidth() + extra.getWidth(), (row, column) -> {
-			if (column < base.getWidth()) {
-				if (row >= base.getHeight()) {
+		return StringUtils.tableToString(Math.max(base.getRowCount(), extra.getRowCount()), base.getColumnCount() + extra.getColumnCount(), (row, column) -> {
+			if (column < base.getColumnCount()) {
+				if (row >= base.getRowCount()) {
 					return "";
 				} else {
 					return String.valueOf(base.get(row, column));
 				}
 			} else {
-				column -= base.getWidth();
-				if (row >= extra.getHeight()) {
+				column -= base.getColumnCount();
+				if (row >= extra.getRowCount()) {
 					return "";
 				} else {
 					return String.valueOf(extra.get(row, column));
@@ -55,9 +55,9 @@ public class AugmentedMatrix {
 		}, (row, column) -> {
 			if (column == 0) {
 				return "[";
-			} else if (column == base.getWidth()) {
+			} else if (column == base.getColumnCount()) {
 				return "|";
-			} else if (column == base.getWidth() + extra.getWidth()) {
+			} else if (column == base.getColumnCount() + extra.getColumnCount()) {
 				return "]";
 			} else {
 				return " ";

--- a/src/randomreverser/math/component/BigAugmentedMatrix.java
+++ b/src/randomreverser/math/component/BigAugmentedMatrix.java
@@ -39,17 +39,17 @@ public class BigAugmentedMatrix {
 
 	@Override
 	public String toString() {
-		return StringUtils.tableToString(Math.max(base.getHeight(), extra.getHeight()), base.getWidth() + extra.getWidth(), (row, column) -> {
-			if (column < base.getWidth()) {
-				if (row >= base.getHeight()) {
+		return StringUtils.tableToString(Math.max(base.getRowCount(), extra.getRowCount()), base.getColumnCount() + extra.getColumnCount(), (row, column) -> {
+			if (column < base.getColumnCount()) {
+				if (row >= base.getRowCount()) {
 					return "";
 				} else {
 					return base.get(row, column) == null ? "null" :
 							base.get(row, column).stripTrailingZeros().toPlainString();
 				}
 			} else {
-				column -= base.getWidth();
-				if (row >= extra.getHeight()) {
+				column -= base.getColumnCount();
+				if (row >= extra.getRowCount()) {
 					return "";
 				} else {
 					return extra.get(row, column) == null ? "null" :
@@ -59,9 +59,9 @@ public class BigAugmentedMatrix {
 		}, (row, column) -> {
 			if (column == 0) {
 				return "[";
-			} else if (column == base.getWidth()) {
+			} else if (column == base.getColumnCount()) {
 				return "|";
-			} else if (column == base.getWidth() + extra.getWidth()) {
+			} else if (column == base.getColumnCount() + extra.getColumnCount()) {
 				return "]";
 			} else {
 				return " ";

--- a/src/randomreverser/math/component/SystemSolver.java
+++ b/src/randomreverser/math/component/SystemSolver.java
@@ -7,7 +7,7 @@ public class SystemSolver {
 	public static SystemSolver.Result solve( Matrix base, Matrix extra, Phase phase) {
 		AugmentedMatrix am = new AugmentedMatrix(base.copy(), extra.copy());
 
-		for(int x = 0; x < am.getBase().getWidth(); x++) {
+		for(int x = 0; x < am.getBase().getColumnCount(); x++) {
 			Vector v = am.getBase().getRow(x);
 
 			if(v.get(x) != 0.0D && v.get(x) != 1.0D) {
@@ -16,7 +16,7 @@ public class SystemSolver {
 				continue;
 			}
 
-			for(int y = x + 1; y < am.getBase().getHeight(); y++) {
+			for(int y = x + 1; y < am.getBase().getRowCount(); y++) {
 				if(am.getBase().get(y, x) == 0.0D)continue;
 				am.subtractScaledRow(y, am.getBase().get(y, x), x);
 			}
@@ -24,7 +24,7 @@ public class SystemSolver {
 
 		if(phase == Phase.ROW_ECHELON)return new Result(am);
 
-		for(int j = 0; j < am.getBase().getWidth(); j++) {
+		for(int j = 0; j < am.getBase().getColumnCount(); j++) {
 			for(int i = 0; i < j; i++) {
 				Vector v = am.getBase().getRow(i);
 				Vector s = am.getBase().getRow(j);
@@ -39,7 +39,7 @@ public class SystemSolver {
 	public static SystemSolver.BigResult solve(BigMatrix base, BigMatrix extra, Phase phase) {
 		BigAugmentedMatrix am = new BigAugmentedMatrix(base.copy(), extra.copy());
 
-		for(int x = 0; x < am.getBase().getWidth(); x++) {
+		for(int x = 0; x < am.getBase().getColumnCount(); x++) {
 			BigVector v = am.getBase().getRow(x);
 
 			if(v.get(x).compareTo(BigDecimal.ZERO) != 0 && v.get(x).compareTo(BigDecimal.ONE) != 0) {
@@ -48,7 +48,7 @@ public class SystemSolver {
 				continue;
 			}
 
-			for(int y = x + 1; y < am.getBase().getHeight(); y++) {
+			for(int y = x + 1; y < am.getBase().getRowCount(); y++) {
 				if(am.getBase().get(y, x).compareTo(BigDecimal.ZERO) == 0)continue;
 				am.subtractScaledRow(y, am.getBase().get(y, x), x);
 			}
@@ -56,7 +56,7 @@ public class SystemSolver {
 
 		if(phase == Phase.ROW_ECHELON)return new BigResult(am);
 
-		for(int j = 0; j < am.getBase().getWidth(); j++) {
+		for(int j = 0; j < am.getBase().getColumnCount(); j++) {
 			for(int i = 0; i < j; i++) {
 				BigVector v = am.getBase().getRow(i);
 				BigVector s = am.getBase().getRow(j);
@@ -78,11 +78,11 @@ public class SystemSolver {
 		public Type type;
 
 		public Result(AugmentedMatrix am) {
-			this.result = new Matrix(am.getExtra().getHeight(), am.getExtra().getWidth());
+			this.result = new Matrix(am.getExtra().getRowCount(), am.getExtra().getColumnCount());
 			this.remainder = am;
 			this.type = Type.ONE_SOLUTION;
 
-			for(int i = 0; i < am.getBase().getHeight(); i++) {
+			for(int i = 0; i < am.getBase().getRowCount(); i++) {
 				Vector baseV = am.getBase().getRow(i);
 				Vector extraV = am.getExtra().getRow(i);
 				boolean isBaseZero = baseV.isZero();
@@ -127,11 +127,11 @@ public class SystemSolver {
 		public Type type;
 
 		public BigResult(BigAugmentedMatrix am) {
-			this.result = new BigMatrix(am.getExtra().getHeight(), am.getExtra().getWidth());
+			this.result = new BigMatrix(am.getExtra().getRowCount(), am.getExtra().getColumnCount());
 			this.remainder = am;
 			this.type = Type.ONE_SOLUTION;
 
-			for(int i = 0; i < am.getBase().getHeight(); i++) {
+			for(int i = 0; i < am.getBase().getRowCount(); i++) {
 				BigVector baseV = am.getBase().getRow(i);
 				BigVector extraV = am.getExtra().getRow(i);
 				boolean isBaseZero = baseV.isZero();

--- a/src/randomreverser/math/decomposition/BigGramSchmidt.java
+++ b/src/randomreverser/math/decomposition/BigGramSchmidt.java
@@ -34,23 +34,23 @@ public class BigGramSchmidt {
 	}
 
 	public void compute() {
-		this.newBasis = new BigMatrix(this.basis.getHeight(), this.basis.getWidth());
-		this.coefficients = new BigMatrix(this.basis.getHeight(), this.basis.getWidth());
+		this.newBasis = new BigMatrix(this.basis.getRowCount(), this.basis.getColumnCount());
+		this.coefficients = new BigMatrix(this.basis.getRowCount(), this.basis.getColumnCount());
 
-		for(int i = 0; i < this.basis.getHeight(); i++) {
+		for(int i = 0; i < this.basis.getRowCount(); i++) {
 			BigVector v = this.basis.getRow(i).copy();
 			this.newBasis.setRow(i, v);
 
 			for(int j = 0; j < i; j++) {
-				BigDecimal scalar = this.basis.getRow(i).getScalarProjection(this.newBasis.getRow(j));
+				BigDecimal scalar = this.basis.getRow(i).gramSchmidtCoefficient(this.newBasis.getRow(j));
 				v.subtractEquals(this.newBasis.getRow(j).multiply(scalar));
 				this.coefficients.set(i, j, scalar);
 			}
 		}
 
-		for(int i = 0; i < this.basis.getHeight(); i++) {
-			for(int j = i; j < this.basis.getWidth(); j++) {
-				this.coefficients.set(i, j, this.basis.getRow(i).getScalarProjection(this.newBasis.getRow(j)));
+		for(int i = 0; i < this.basis.getRowCount(); i++) {
+			for(int j = i; j < this.basis.getColumnCount(); j++) {
+				this.coefficients.set(i, j, this.basis.getRow(i).gramSchmidtCoefficient(this.newBasis.getRow(j)));
 			}
 		}
 	}

--- a/src/randomreverser/math/decomposition/GramSchmidt.java
+++ b/src/randomreverser/math/decomposition/GramSchmidt.java
@@ -32,23 +32,23 @@ public class GramSchmidt {
 	}
 
 	public void compute() {
-		this.newBasis = new Matrix(this.basis.getHeight(), this.basis.getWidth());
-		this.coefficients = new Matrix(this.basis.getHeight(), this.basis.getWidth());
+		this.newBasis = new Matrix(this.basis.getRowCount(), this.basis.getColumnCount());
+		this.coefficients = new Matrix(this.basis.getRowCount(), this.basis.getColumnCount());
 
-		for(int i = 0; i < this.basis.getHeight(); i++) {
+		for(int i = 0; i < this.basis.getRowCount(); i++) {
 			Vector v = this.basis.getRow(i).copy();
 			this.newBasis.setRow(i, v);
 
 			for(int j = 0; j < i; j++) {
-				double scalar = this.basis.getRow(i).getScalarProjection(this.newBasis.getRow(j));
+				double scalar = this.basis.getRow(i).gramSchmidtCoefficient(this.newBasis.getRow(j));
 				v.subtractEquals(this.newBasis.getRow(j).multiply(scalar));
 				this.coefficients.set(i, j, scalar);
 			}
 		}
 
-		for(int i = 0; i < this.basis.getHeight(); i++) {
-			for(int j = i; j < this.basis.getWidth(); j++) {
-				this.coefficients.set(i, j, this.basis.getRow(i).getScalarProjection(this.newBasis.getRow(j)));
+		for(int i = 0; i < this.basis.getRowCount(); i++) {
+			for(int j = i; j < this.basis.getColumnCount(); j++) {
+				this.coefficients.set(i, j, this.basis.getRow(i).gramSchmidtCoefficient(this.newBasis.getRow(j)));
 			}
 		}
 	}

--- a/src/randomreverser/math/lattice/Enumerate.java
+++ b/src/randomreverser/math/lattice/Enumerate.java
@@ -101,7 +101,7 @@ public class Enumerate {
 
 	private static BoolExpr inHalfPlane(Context context, ArithExpr[] variables, Matrix basis, Vector offset, Vector normal) {
 		double rhs = normal.dot(offset);
-		Vector lhs = normal.multiply(basis);
+		Vector lhs = basis.multiply(normal);
 
 		IntNum rhsExpr = context.mkInt((long)rhs);
 		ArithExpr[] lhsExprs = new ArithExpr[variables.length];

--- a/src/randomreverser/math/lattice/LLL.java
+++ b/src/randomreverser/math/lattice/LLL.java
@@ -20,7 +20,7 @@ public class LLL {
 		gs.compute();
 
 		int k = 1;
-		int n = gs.getBasis().getHeight();
+		int n = gs.getBasis().getRowCount();
 		while(k <= n) {
 			//for(int k = 0; k < gs.getBasis().getHeight(); k++) {
 			for(int j = k - 1; j >= 0; j--) {
@@ -33,7 +33,7 @@ public class LLL {
 			//}
 			double v = gs.getNewBasis().getRow(k).magnitudeSq() + (gs.getNewBasis().getRow(k-1).multiply(gs.getCoefficients().get(k, k -1 ))).magnitudeSq();
 			if(v < params.delta * gs.getNewBasis().getRow(k-1).magnitudeSq()) {
-				gs.getBasis().swapEquals(k - 1, k );
+				gs.getBasis().swapRowsEquals(k - 1, k );
 				gs.compute(); //bad and naive
 				k = (k >= 2) ? k - 1: 1;
 			}
@@ -61,7 +61,7 @@ public class LLL {
 		gs.compute();
 
 		int k = 1;
-		int n = gs.getBasis().getHeight() - 1;
+		int n = gs.getBasis().getRowCount() - 1;
 		while(k <= n) {
 			//for(int k = 0; k < gs.getBasis().getHeight(); k++) {
 			for(int j = k - 1; j >= 0; j--) {
@@ -82,9 +82,9 @@ public class LLL {
 				BigDecimal a = gs.getNewBasis().getRow(k).magnitudeSq().add(gs.getNewBasis().getRow(k-1).multiply(gs.getCoefficients().get(k, k-1)).magnitudeSq());
 
 				if(a.compareTo(gs.getNewBasis().getRow(k-1).magnitudeSq().multiply(BIG_DELTA)) < 0) {
-					gs.getBasis().swapEquals(k-1, k);
+					gs.getBasis().swapRowsEquals(k-1, k);
 					if (transformations != null)
-						transformations.swapEquals(k-1, k);
+						transformations.swapRowsEquals(k-1, k);
 					gs.compute(); //bad and naive
 					k = (k >= 2) ? k - 1: 1;
 					//fullyCompleted = false;
@@ -100,12 +100,9 @@ public class LLL {
 		return gs.getBasis();
 	}
 
-	public static class Params {
+	public static final class Params {
 		protected double delta;
 		protected boolean debug;
-
-		public Params() {
-		}
 
 		public Params setDelta(double delta) {
 			this.delta = delta;

--- a/src/randomreverser/util/Mth.java
+++ b/src/randomreverser/util/Mth.java
@@ -25,11 +25,6 @@ public class Mth {
         return a;
     }
 
-    @Deprecated // use Long.numberOfTrailingZeros() instead
-    public static int countTrailingZeroes(long v) {
-        return Long.numberOfTrailingZeros(v);
-    }
-
     public static long modInverse(long x, int mod) { //Fast method for modular inverse mod powers of 2
         if ((x & 1) == 0) {
             throw new IllegalArgumentException("x is not coprime with the modulus");

--- a/test/randomreverser/math/component/BigMatrixTest.java
+++ b/test/randomreverser/math/component/BigMatrixTest.java
@@ -1,0 +1,247 @@
+package randomreverser.math.component;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.*;
+import static randomreverser.util.MoreAssert.*;
+
+public class BigMatrixTest {
+
+    @Test
+    public void testGetRowCount() {
+        assertEquals(2, new BigMatrix(2, 3).getRowCount());
+    }
+
+    @Test
+    public void testGetColumnCount() {
+        assertEquals(3, new BigMatrix(2, 3).getColumnCount());
+    }
+
+    @Test
+    public void testGet() {
+        BigMatrix m = BigMatrix.fromString("{{2, 3}, {5, 7}}");
+        assertBigDecimalEquals(BigDecimal.valueOf(2), m.get(0, 0));
+        assertBigDecimalEquals(BigDecimal.valueOf(3), m.get(0, 1));
+        assertBigDecimalEquals(BigDecimal.valueOf(5), m.get(1, 0));
+        assertBigDecimalEquals(BigDecimal.valueOf(7), m.get(1, 1));
+    }
+
+    @Test
+    public void testSet() {
+        BigMatrix m = new BigMatrix(2, 2);
+        m.set(0, 0, BigDecimal.valueOf(2));
+        m.set(0, 1, BigDecimal.valueOf(3));
+        m.set(1, 0, BigDecimal.valueOf(5));
+        m.set(1, 1, BigDecimal.valueOf(7));
+        assertEquals(BigMatrix.fromString("{{2, 3}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testGetRow() {
+        BigMatrix m = BigMatrix.fromString("{{2, 3}, {5, 7}}");
+        assertEquals(new BigVector(2, 3), m.getRow(0));
+        assertEquals(new BigVector(5, 7), m.getRow(1));
+    }
+
+    @Test
+    public void testSetRow() {
+        BigMatrix m = new BigMatrix(2, 2);
+        m.setRow(0, new BigVector(2, 3));
+        m.setRow(1, new BigVector(5, 7));
+        assertEquals(BigMatrix.fromString("{{2, 3}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testAdd() {
+        BigMatrix m1 = BigMatrix.fromString("{{2, 3}, {5, 7}}");
+        BigMatrix m2 = BigMatrix.fromString("{{11, 13}, {17, 19}}");
+        assertEquals(BigMatrix.fromString("{{13, 16}, {22, 26}}"), m1.add(m2));
+        assertEquals(BigMatrix.fromString("{{13, 16}, {22, 26}}"), m2.add(m1));
+        assertEquals(BigMatrix.fromString("{{2, 3}, {5, 7}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddFail() {
+        new BigMatrix(2, 2).add(new BigMatrix(2, 3));
+    }
+
+    @Test
+    public void testSubtract() {
+        BigMatrix m1 = BigMatrix.fromString("{{2, 3}, {5, 7}}");
+        BigMatrix m2 = BigMatrix.fromString("{{11, 13}, {17, 19}}");
+        assertEquals(BigMatrix.fromString("{{9, 10}, {12, 12}}"), m2.subtract(m1));
+        assertEquals(BigMatrix.fromString("{{2, 3}, {5, 7}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubtractFail() {
+        new BigMatrix(2, 2).subtract(new BigMatrix(2, 3));
+    }
+
+    @Test
+    public void testMultiplyScalar() {
+        BigMatrix m = BigMatrix.fromString("{{2, 3}, {5, 7}}");
+        assertEquals(BigMatrix.fromString("{{4, 6}, {10, 14}}"), m.multiply(BigDecimal.valueOf(2)));
+        assertEquals(BigMatrix.fromString("{{2, 3}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testMultiplyMatrix1() {
+        BigMatrix m1 = BigMatrix.fromString("{{2, 3}, {5, 7}}");
+        BigMatrix m2 = BigMatrix.fromString("{{11, 13}, {17, 19}}");
+        assertEquals(BigMatrix.fromString("{{73, 83}, {174, 198}}"), m1.multiply(m2));
+        assertEquals(BigMatrix.fromString("{{87, 124}, {129, 184}}"), m2.multiply(m1));
+        assertEquals(BigMatrix.fromString("{{2, 3}, {5, 7}}"), m1);
+    }
+
+    @Test
+    public void testMultiplyMatrix2() {
+        BigMatrix m1 = BigMatrix.fromString("{{2, 3}}");
+        BigMatrix m2 = BigMatrix.fromString("{{5}, {7}}");
+        assertEquals(BigMatrix.fromString("{{31}}"), m1.multiply(m2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultiplyMatrixFail() {
+        new BigMatrix(1, 2).multiply(new BigMatrix(1, 2));
+    }
+
+    @Test
+    public void testDivide() {
+        BigMatrix m = BigMatrix.fromString("{{4, 6}, {10, 14}}");
+        assertEquals(BigMatrix.fromString("{{2, 3}, {5, 7}}"), m.divide(BigDecimal.valueOf(2)));
+        assertEquals(BigMatrix.fromString("{{4, 6}, {10, 14}}"), m);
+    }
+
+    @Test
+    public void testInverseIdentity() {
+        assertEquals(BigMatrix.identityMatrix(5), BigMatrix.identityMatrix(5).inverse());
+    }
+
+    @Test
+    public void testInverseOrthogonal() {
+        BigMatrix m = BigMatrix.fromString("{{0, 1}, {-1, 0}}");
+        assertEquals(BigMatrix.fromString("{{0, -1}, {1, 0}}"), m.inverse());
+        assertEquals(BigMatrix.fromString("{{0, 1}, {-1, 0}}"), m);
+    }
+
+    @Test
+    public void testInverseEight() {
+        assertEquals(BigMatrix.fromString("{{0.125}}"), BigMatrix.fromString("{{8}}").inverse());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testInverseSingular() {
+        BigMatrix m = BigMatrix.fromString(
+                "{{0, 1, 1, 2, 3}," +
+                "{5, 8, 13, 21, 34}," +
+                "{55, 89, 144, 233, 377}," +
+                "{610, 987, 1597, 2584, 4181}," +
+                "{6765, 10946, 17711, 28657, 46368}}"
+        );
+        m.inverse();
+    }
+
+    @Test
+    public void testInvesre5x5() {
+        BigMatrix m = BigMatrix.fromString(
+                "{{1, 8, 24, 7, 16}," +
+                "{4, 5, 6, 22, 25}," +
+                "{10, 20, 18, 12, 9}," +
+                "{2, 13, 3, 23, 11}," +
+                "{19, 14, 21, 15, 17}}"
+        );
+        BigMatrix expected = BigMatrix.fromString(
+                "{{-9516, -1107, -4077, -3855, 15237}," +
+                "{-12486, 16731, 39465, -18660, -21672}," +
+                "{16955, -18494, -20727, 15324, 12297}," +
+                "{9837, -20547, -31365, 31833, 16965}," +
+                "{-8706, 28434, 25335, -27342, -15984}}"
+        ).divide(BigDecimal.valueOf(227079));
+        assertTrue(m.inverse().equals(expected, BigDecimal.valueOf(0.00000001)));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testInverseNonSquare() {
+        new BigMatrix(1, 2).inverse();
+    }
+
+    @Test
+    public void testSwapRows() {
+        BigMatrix m = BigMatrix.fromString("{{1, 2}, {3, 4}, {5, 7}}");
+        assertEquals(BigMatrix.fromString("{{5, 7}, {3, 4}, {1, 2}}"), m.swapRows(0, 2));
+        assertEquals(BigMatrix.fromString("{{1, 2}, {3, 4}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testTranspose() {
+        BigMatrix m = BigMatrix.fromString("{{1, 2}, {3, 4}, {5, 7}}");
+        assertEquals(BigMatrix.fromString("{{1, 3, 5}, {2, 4, 7}}"), m.transpose());
+        assertEquals(BigMatrix.fromString("{{1, 2}, {3, 4}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testAddEquals() {
+        BigMatrix m1 = BigMatrix.fromString("{{2, 3}, {5, 7}}");
+        BigMatrix m2 = BigMatrix.fromString("{{11, 13}, {17, 19}}");
+        BigMatrix result = m1.addEquals(m2);
+        assertSame(result, m1);
+        assertEquals(BigMatrix.fromString("{{13, 16}, {22, 26}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddEqualsFail() {
+        new BigMatrix(2, 2).addEquals(new BigMatrix(2, 3));
+    }
+
+    @Test
+    public void testSubtractEquals() {
+        BigMatrix m1 = BigMatrix.fromString("{{2, 3}, {5, 7}}");
+        BigMatrix m2 = BigMatrix.fromString("{{11, 13}, {17, 19}}");
+        BigMatrix result = m1.subtractEquals(m2);
+        assertSame(result, m1);
+        assertEquals(BigMatrix.fromString("{{-9, -10}, {-12, -12}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubtractEqualsFail() {
+        new BigMatrix(2, 2).subtractEquals(new BigMatrix(2, 3));
+    }
+
+    @Test
+    public void testMultiplyEquals() {
+        BigMatrix m1 = BigMatrix.fromString("{{2, 3}, {5, 7}}");
+        BigMatrix m2 = BigMatrix.fromString("{{11, 13}, {17, 19}}");
+        BigMatrix result = m1.multiplyEquals(m2);
+        assertSame(result, m1);
+        assertEquals(BigMatrix.fromString("{{73, 83}, {174, 198}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultiplyEqualsFail() {
+        new BigMatrix(1, 2).multiplyEquals(new BigMatrix(1, 2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultiplyEqualsNonSquare() {
+        new BigMatrix(2, 2).multiplyEquals(new BigMatrix(2, 3));
+    }
+
+    @Test
+    public void testSwapRowsEquals() {
+        BigMatrix m = BigMatrix.fromString("{{1, 2}, {3, 4}, {5, 7}}");
+        BigMatrix result = m.swapRowsEquals(0, 2);
+        assertSame(result, m);
+        assertEquals(BigMatrix.fromString("{{5, 7}, {3, 4}, {1, 2}}"), m);
+    }
+
+    @Test
+    public void copy() {
+        BigMatrix m = BigMatrix.fromString("{{1, 2}, {3, 4}}");
+        BigMatrix result = m.copy();
+        assertNotSame(m, result);
+        assertEquals(BigMatrix.fromString("{{1, 2}, {3, 4}}"), result);
+    }
+}

--- a/test/randomreverser/math/component/BigVectorTest.java
+++ b/test/randomreverser/math/component/BigVectorTest.java
@@ -1,0 +1,175 @@
+package randomreverser.math.component;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.*;
+import static randomreverser.util.MoreAssert.*;
+
+public class BigVectorTest {
+
+    @Test
+    public void testGetDimension0() {
+        assertEquals(0, new BigVector(0).getDimension());
+    }
+
+    @Test
+    public void testGetDimension3() {
+        assertEquals(3, new BigVector(3).getDimension());
+    }
+
+    @Test
+    public void testGet() {
+        assertBigDecimalEquals(BigDecimal.valueOf(4), new BigVector(1, 2, 3, 4, 5).get(3));
+    }
+
+    @Test
+    public void testMagnitudeSq() {
+        assertBigDecimalEquals(BigDecimal.valueOf(55), new BigVector(1, 2, 3, 4, 5).magnitudeSq());
+    }
+
+    @Test
+    public void testIsZeroTrue() {
+        assertTrue(new BigVector(0, 0, 0, 0, 0).isZero());
+    }
+
+    @Test
+    public void testIsZeroFalse1() {
+        assertFalse(new BigVector(1, 2, 3, 4, 5).isZero());
+    }
+
+    @Test
+    public void testIsZeroFalse2() {
+        assertFalse(new BigVector(1, -1).isZero());
+    }
+
+    @Test
+    public void testAdd() {
+        BigVector a = new BigVector(1, 2, 3, 4, 5);
+        BigVector b = new BigVector(5, 3, 6, -4, -1);
+        assertEquals(new BigVector(6, 5, 9, 0, 4), a.add(b));
+        assertEquals(new BigVector(1, 2, 3, 4, 5), a);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddFail() {
+        new BigVector(1, 2).add(new BigVector(3, 4, 5));
+    }
+
+    @Test
+    public void testSubtract() {
+        BigVector a = new BigVector(1, 2, 3, 4, 5);
+        BigVector b = new BigVector(-5, -3, -6, 4, 1);
+        assertEquals(new BigVector(6, 5, 9, 0, 4), a.subtract(b));
+        assertEquals(new BigVector(1, 2, 3, 4, 5), a);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubtractFail() {
+        new BigVector(1, 2).subtract(new BigVector(3, 4, 5));
+    }
+
+    @Test
+    public void testMultiplyScalar() {
+        BigVector a = new BigVector(1, 2, 3, 4, 5);
+        assertEquals(new BigVector(2, 4, 6, 8, 10), a.multiply(BigDecimal.valueOf(2)));
+        assertEquals(new BigVector(1, 2, 3, 4, 5), a);
+    }
+
+    @Test
+    public void testDivide() {
+        BigVector a = new BigVector(2, 4);
+        assertEquals(new BigVector(1, 2), a.divide(BigDecimal.valueOf(2)));
+        assertEquals(new BigVector(2, 4), a);
+    }
+
+    @Test
+    public void testAddEquals() {
+        BigVector a = new BigVector(1, 2, 3, 4, 5);
+        BigVector b = new BigVector(5, 3, 6, -4, -1);
+        BigVector result = a.addEquals(b);
+        assertSame(result, a);
+        assertEquals(new BigVector(6, 5, 9, 0, 4), a);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddEqualsFail() {
+        new BigVector(1, 2).addEquals(new BigVector(3, 4, 5));
+    }
+
+    @Test
+    public void testSubtractEquals() {
+        BigVector a = new BigVector(1, 2, 3, 4, 5);
+        BigVector b = new BigVector(-5, -3, -6, 4, 1);
+        BigVector result = a.subtractEquals(b);
+        assertSame(result, a);
+        assertEquals(new BigVector(6, 5, 9, 0, 4), a);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubtractEqualsFail() {
+        new BigVector(1, 2).subtractEquals(new BigVector(3, 4, 5));
+    }
+
+    @Test
+    public void testMultiplyEquals() {
+        BigVector a = new BigVector(1, 2, 3, 4, 5);
+        BigVector result = a.multiplyEquals(BigDecimal.valueOf(2));
+        assertSame(result, a);
+        assertEquals(new BigVector(2, 4, 6, 8, 10), a);
+    }
+
+    @Test
+    public void divideEquals() {
+        BigVector a = new BigVector(2, 4);
+        BigVector result = a.divideEquals(BigDecimal.valueOf(2));
+        assertSame(result, a);
+        assertEquals(new BigVector(1, 2), a);
+    }
+
+    @Test
+    public void testDot() {
+        BigVector a = new BigVector(2, 3, 5);
+        BigVector b = new BigVector(7, 11, 13);
+        assertBigDecimalEquals(BigDecimal.valueOf(112), a.dot(b));
+        assertBigDecimalEquals(BigDecimal.valueOf(112), b.dot(a));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDotFail() {
+        new BigVector(1, 2).dot(new BigVector(3, 4, 5));
+    }
+
+    @Test
+    public void testGramSchmidtCoefficient() {
+        BigVector a = new BigVector(7, 11, 13);
+        BigVector b = new BigVector(2, 3, 5);
+        assertBigDecimalEquals(BigDecimal.valueOf(56.0 / 19), a.gramSchmidtCoefficient(b), BigDecimal.valueOf(0.00000001));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGramSchmidtCoefficientFail() {
+        new BigVector(1, 2).gramSchmidtCoefficient(new BigVector(3, 4, 5));
+    }
+
+    @Test
+    public void testProjectOnto() {
+        BigVector a = new BigVector(7, 11, 13);
+        BigVector b = new BigVector(2, 3, 5);
+        assertTrue(new BigVector(112.0 / 19, 168.0 / 19, 280.0 / 19).equals(a.projectOnto(b), BigDecimal.valueOf(0.00000001)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testProjectOntoFail() {
+        new BigVector(1, 2).projectOnto(new BigVector(3, 4, 5));
+    }
+
+    @Test
+    public void testCopy() {
+        BigVector a = new BigVector(1, 2, 3);
+        BigVector b = a.copy();
+        assertNotSame(a, b);
+        assertEquals(a, b);
+    }
+}

--- a/test/randomreverser/math/component/MatrixTest.java
+++ b/test/randomreverser/math/component/MatrixTest.java
@@ -1,0 +1,264 @@
+package randomreverser.math.component;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MatrixTest {
+
+    @Test
+    public void testGetRowCount() {
+        assertEquals(2, new Matrix(2, 3).getRowCount());
+    }
+
+    @Test
+    public void testGetColumnCount() {
+        assertEquals(3, new Matrix(2, 3).getColumnCount());
+    }
+
+    @Test
+    public void testGet() {
+        Matrix m = Matrix.fromString("{{2, 3}, {5, 7}}");
+        assertEquals(2, m.get(0, 0), 0);
+        assertEquals(3, m.get(0, 1), 0);
+        assertEquals(5, m.get(1, 0), 0);
+        assertEquals(7, m.get(1, 1), 0);
+    }
+
+    @Test
+    public void testSet() {
+        Matrix m = new Matrix(2, 2);
+        m.set(0, 0, 2);
+        m.set(0, 1, 3);
+        m.set(1, 0, 5);
+        m.set(1, 1, 7);
+        assertEquals(Matrix.fromString("{{2, 3}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testGetRow() {
+        Matrix m = Matrix.fromString("{{2, 3}, {5, 7}}");
+        assertEquals(new Vector(2, 3), m.getRow(0));
+        assertEquals(new Vector(5, 7), m.getRow(1));
+    }
+
+    @Test
+    public void testGetColumn() {
+        Matrix m = Matrix.fromString("{{2, 3}, {5, 7}}");
+        assertEquals(new Vector(2, 5), m.getColumn(0));
+        assertEquals(new Vector(3, 7), m.getColumn(1));
+    }
+
+    @Test
+    public void testSetRow() {
+        Matrix m = new Matrix(2, 2);
+        m.setRow(0, new Vector(2, 3));
+        m.setRow(1, new Vector(5, 7));
+        assertEquals(Matrix.fromString("{{2, 3}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testAdd() {
+        Matrix m1 = Matrix.fromString("{{2, 3}, {5, 7}}");
+        Matrix m2 = Matrix.fromString("{{11, 13}, {17, 19}}");
+        assertEquals(Matrix.fromString("{{13, 16}, {22, 26}}"), m1.add(m2));
+        assertEquals(Matrix.fromString("{{13, 16}, {22, 26}}"), m2.add(m1));
+        assertEquals(Matrix.fromString("{{2, 3}, {5, 7}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddFail() {
+        new Matrix(2, 2).add(new Matrix(2, 3));
+    }
+
+    @Test
+    public void testSubtract() {
+        Matrix m1 = Matrix.fromString("{{2, 3}, {5, 7}}");
+        Matrix m2 = Matrix.fromString("{{11, 13}, {17, 19}}");
+        assertEquals(Matrix.fromString("{{9, 10}, {12, 12}}"), m2.subtract(m1));
+        assertEquals(Matrix.fromString("{{2, 3}, {5, 7}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubtractFail() {
+        new Matrix(2, 2).subtract(new Matrix(2, 3));
+    }
+
+    @Test
+    public void testMultiplyScalar() {
+        Matrix m = Matrix.fromString("{{2, 3}, {5, 7}}");
+        assertEquals(Matrix.fromString("{{4, 6}, {10, 14}}"), m.multiply(2));
+        assertEquals(Matrix.fromString("{{2, 3}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testMultiplyMatrix1() {
+        Matrix m1 = Matrix.fromString("{{2, 3}, {5, 7}}");
+        Matrix m2 = Matrix.fromString("{{11, 13}, {17, 19}}");
+        assertEquals(Matrix.fromString("{{73, 83}, {174, 198}}"), m1.multiply(m2));
+        assertEquals(Matrix.fromString("{{87, 124}, {129, 184}}"), m2.multiply(m1));
+        assertEquals(Matrix.fromString("{{2, 3}, {5, 7}}"), m1);
+    }
+
+    @Test
+    public void testMultiplyMatrix2() {
+        Matrix m1 = Matrix.fromString("{{2, 3}}");
+        Matrix m2 = Matrix.fromString("{{5}, {7}}");
+        assertEquals(Matrix.fromString("{{31}}"), m1.multiply(m2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultiplyMatrixFail() {
+        new Matrix(1, 2).multiply(new Matrix(1, 2));
+    }
+
+    @Test
+    public void testMultiplyVector() {
+        Matrix m = Matrix.fromString("{{2, 3}, {5, 7}}");
+        Vector v = new Vector(11, 13);
+        assertEquals(new Vector(61, 146), m.multiply(v));
+        assertEquals(Matrix.fromString("{{2, 3}, {5, 7}}"), m);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultiplyVectorFail() {
+        new Matrix(2, 2).multiply(new Vector(3));
+    }
+
+    @Test
+    public void testDivide() {
+        Matrix m = Matrix.fromString("{{4, 6}, {10, 14}}");
+        assertEquals(Matrix.fromString("{{2, 3}, {5, 7}}"), m.divide(2));
+        assertEquals(Matrix.fromString("{{4, 6}, {10, 14}}"), m);
+    }
+
+    @Test
+    public void testInverseIdentity() {
+        assertEquals(Matrix.identityMatrix(5), Matrix.identityMatrix(5).inverse());
+    }
+
+    @Test
+    public void testInverseOrthogonal() {
+        Matrix m = Matrix.fromString("{{0, 1}, {-1, 0}}");
+        assertEquals(Matrix.fromString("{{0, -1}, {1, 0}}"), m.inverse());
+        assertEquals(Matrix.fromString("{{0, 1}, {-1, 0}}"), m);
+    }
+
+    @Test
+    public void testInverseEight() {
+        assertEquals(Matrix.fromString("{{0.125}}"), Matrix.fromString("{{8}}").inverse());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testInverseSingular() {
+        Matrix m = Matrix.fromString(
+                "{{0, 1, 1, 2, 3}," +
+                "{5, 8, 13, 21, 34}," +
+                "{55, 89, 144, 233, 377}," +
+                "{610, 987, 1597, 2584, 4181}," +
+                "{6765, 10946, 17711, 28657, 46368}}"
+        );
+        m.inverse();
+    }
+
+    @Test
+    public void testInvesre5x5() {
+        Matrix m = Matrix.fromString(
+                "{{1, 8, 24, 7, 16}," +
+                "{4, 5, 6, 22, 25}," +
+                "{10, 20, 18, 12, 9}," +
+                "{2, 13, 3, 23, 11}," +
+                "{19, 14, 21, 15, 17}}"
+        );
+        Matrix expected = Matrix.fromString(
+                "{{-9516, -1107, -4077, -3855, 15237}," +
+                "{-12486, 16731, 39465, -18660, -21672}," +
+                "{16955, -18494, -20727, 15324, 12297}," +
+                "{9837, -20547, -31365, 31833, 16965}," +
+                "{-8706, 28434, 25335, -27342, -15984}}"
+        ).divide(227079);
+        assertTrue(m.inverse().equals(expected, 0.00000001));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testInverseNonSquare() {
+        new Matrix(1, 2).inverse();
+    }
+
+    @Test
+    public void testSwapRows() {
+        Matrix m = Matrix.fromString("{{1, 2}, {3, 4}, {5, 7}}");
+        assertEquals(Matrix.fromString("{{5, 7}, {3, 4}, {1, 2}}"), m.swapRows(0, 2));
+        assertEquals(Matrix.fromString("{{1, 2}, {3, 4}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testTranspose() {
+        Matrix m = Matrix.fromString("{{1, 2}, {3, 4}, {5, 7}}");
+        assertEquals(Matrix.fromString("{{1, 3, 5}, {2, 4, 7}}"), m.transpose());
+        assertEquals(Matrix.fromString("{{1, 2}, {3, 4}, {5, 7}}"), m);
+    }
+
+    @Test
+    public void testAddEquals() {
+        Matrix m1 = Matrix.fromString("{{2, 3}, {5, 7}}");
+        Matrix m2 = Matrix.fromString("{{11, 13}, {17, 19}}");
+        Matrix result = m1.addEquals(m2);
+        assertSame(result, m1);
+        assertEquals(Matrix.fromString("{{13, 16}, {22, 26}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddEqualsFail() {
+        new Matrix(2, 2).addEquals(new Matrix(2, 3));
+    }
+
+    @Test
+    public void testSubtractEquals() {
+        Matrix m1 = Matrix.fromString("{{2, 3}, {5, 7}}");
+        Matrix m2 = Matrix.fromString("{{11, 13}, {17, 19}}");
+        Matrix result = m1.subtractEquals(m2);
+        assertSame(result, m1);
+        assertEquals(Matrix.fromString("{{-9, -10}, {-12, -12}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubtractEqualsFail() {
+        new Matrix(2, 2).subtractEquals(new Matrix(2, 3));
+    }
+
+    @Test
+    public void testMultiplyEquals() {
+        Matrix m1 = Matrix.fromString("{{2, 3}, {5, 7}}");
+        Matrix m2 = Matrix.fromString("{{11, 13}, {17, 19}}");
+        Matrix result = m1.multiplyEquals(m2);
+        assertSame(result, m1);
+        assertEquals(Matrix.fromString("{{73, 83}, {174, 198}}"), m1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultiplyEqualsFail() {
+        new Matrix(1, 2).multiplyEquals(new Matrix(1, 2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultiplyEqualsNonSquare() {
+        new Matrix(2, 2).multiplyEquals(new Matrix(2, 3));
+    }
+
+    @Test
+    public void testSwapRowsEquals() {
+        Matrix m = Matrix.fromString("{{1, 2}, {3, 4}, {5, 7}}");
+        Matrix result = m.swapRowsEquals(0, 2);
+        assertSame(result, m);
+        assertEquals(Matrix.fromString("{{5, 7}, {3, 4}, {1, 2}}"), m);
+    }
+
+    @Test
+    public void copy() {
+        Matrix m = Matrix.fromString("{{1, 2}, {3, 4}}");
+        Matrix result = m.copy();
+        assertNotSame(m, result);
+        assertEquals(Matrix.fromString("{{1, 2}, {3, 4}}"), result);
+    }
+}

--- a/test/randomreverser/math/component/VectorTest.java
+++ b/test/randomreverser/math/component/VectorTest.java
@@ -1,0 +1,200 @@
+package randomreverser.math.component;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VectorTest {
+
+    @Test
+    public void testGetDimension0() {
+        assertEquals(0, new Vector(0).getDimension());
+    }
+
+    @Test
+    public void testGetDimension3() {
+        assertEquals(3, new Vector(3).getDimension());
+    }
+
+    @Test
+    public void testGet() {
+        assertEquals(4, new Vector(1, 2, 3, 4, 5).get(3), 0);
+    }
+
+    @Test
+    public void testMagnitude() {
+        assertEquals(5, new Vector(3, 4).magnitude(), 0.00000001);
+    }
+
+    @Test
+    public void testMagnitudeSq() {
+        assertEquals(55, new Vector(1, 2, 3, 4, 5).magnitudeSq(), 0);
+    }
+
+    @Test
+    public void testIsZeroTrue() {
+        assertTrue(new Vector(0, 0, 0, 0, 0).isZero());
+    }
+
+    @Test
+    public void testIsZeroFalse1() {
+        assertFalse(new Vector(1, 2, 3, 4, 5).isZero());
+    }
+
+    @Test
+    public void testIsZeroFalse2() {
+        assertFalse(new Vector(1, -1).isZero());
+    }
+
+    @Test
+    public void testAdd() {
+        Vector a = new Vector(1, 2, 3, 4, 5);
+        Vector b = new Vector(5, 3, 6, -4, -1);
+        assertEquals(new Vector(6, 5, 9, 0, 4), a.add(b));
+        assertEquals(new Vector(1, 2, 3, 4, 5), a);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddFail() {
+        new Vector(1, 2).add(new Vector(3, 4, 5));
+    }
+
+    @Test
+    public void testSubtract() {
+        Vector a = new Vector(1, 2, 3, 4, 5);
+        Vector b = new Vector(-5, -3, -6, 4, 1);
+        assertEquals(new Vector(6, 5, 9, 0, 4), a.subtract(b));
+        assertEquals(new Vector(1, 2, 3, 4, 5), a);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubtractFail() {
+        new Vector(1, 2).subtract(new Vector(3, 4, 5));
+    }
+
+    @Test
+    public void testMultiplyScalar() {
+        Vector a = new Vector(1, 2, 3, 4, 5);
+        assertEquals(new Vector(2, 4, 6, 8, 10), a.multiply(2));
+        assertEquals(new Vector(1, 2, 3, 4, 5), a);
+    }
+
+    @Test
+    public void testMultiplyMatrix1() {
+        Vector a = new Vector(2, 3);
+        Matrix b = Matrix.fromString("{{5, 7}, {11, 13}}");
+        assertEquals(new Vector(43, 53), a.multiply(b));
+        assertEquals(new Vector(2, 3), a);
+    }
+
+    @Test
+    public void testMultiplyMatrix2() {
+        Vector a = new Vector(2, 3, 5);
+        Matrix b = Matrix.fromString("{{7, 11}, {13, 17}, {19, 23}}");
+        assertEquals(new Vector(148, 188), a.multiply(b));
+        assertEquals(new Vector(2, 3, 5), a);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultiplyMatrixFail() {
+        Vector a = new Vector(2, 3, 5);
+        Matrix b = Matrix.fromString("{{7, 11, 13}, {17, 19, 23}}");
+        a.multiply(b);
+    }
+
+    @Test
+    public void testDivide() {
+        Vector a = new Vector(2, 4);
+        assertEquals(new Vector(1, 2), a.divide(2));
+        assertEquals(new Vector(2, 4), a);
+    }
+
+    @Test
+    public void testAddEquals() {
+        Vector a = new Vector(1, 2, 3, 4, 5);
+        Vector b = new Vector(5, 3, 6, -4, -1);
+        Vector result = a.addEquals(b);
+        assertSame(result, a);
+        assertEquals(new Vector(6, 5, 9, 0, 4), a);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddEqualsFail() {
+        new Vector(1, 2).addEquals(new Vector(3, 4, 5));
+    }
+
+    @Test
+    public void testSubtractEquals() {
+        Vector a = new Vector(1, 2, 3, 4, 5);
+        Vector b = new Vector(-5, -3, -6, 4, 1);
+        Vector result = a.subtractEquals(b);
+        assertSame(result, a);
+        assertEquals(new Vector(6, 5, 9, 0, 4), a);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubtractEqualsFail() {
+        new Vector(1, 2).subtractEquals(new Vector(3, 4, 5));
+    }
+
+    @Test
+    public void testMultiplyEquals() {
+        Vector a = new Vector(1, 2, 3, 4, 5);
+        Vector result = a.multiplyEquals(2);
+        assertSame(result, a);
+        assertEquals(new Vector(2, 4, 6, 8, 10), a);
+    }
+
+    @Test
+    public void divideEquals() {
+        Vector a = new Vector(2, 4);
+        Vector result = a.divideEquals(2);
+        assertSame(result, a);
+        assertEquals(new Vector(1, 2), a);
+    }
+
+    @Test
+    public void testDot() {
+        Vector a = new Vector(2, 3, 5);
+        Vector b = new Vector(7, 11, 13);
+        assertEquals(112, a.dot(b), 0);
+        assertEquals(112, b.dot(a), 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDotFail() {
+        new Vector(1, 2).dot(new Vector(3, 4, 5));
+    }
+
+    @Test
+    public void testGramSchmidtCoefficient() {
+        Vector a = new Vector(7, 11, 13);
+        Vector b = new Vector(2, 3, 5);
+        assertEquals(56.0 / 19, a.gramSchmidtCoefficient(b), 0.00000001);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGramSchmidtCoefficientFail() {
+        new Vector(1, 2).gramSchmidtCoefficient(new Vector(3, 4, 5));
+    }
+
+    @Test
+    public void testProjectOnto() {
+        Vector a = new Vector(7, 11, 13);
+        Vector b = new Vector(2, 3, 5);
+        assertTrue(new Vector(112.0 / 19, 168.0 / 19, 280.0 / 19).equals(a.projectOnto(b), 0.00000001));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testProjectOntoFail() {
+        new Vector(1, 2).projectOnto(new Vector(3, 4, 5));
+    }
+
+    @Test
+    public void testCopy() {
+        Vector a = new Vector(1, 2, 3);
+        Vector b = a.copy();
+        assertNotSame(a, b);
+        assertEquals(a, b);
+    }
+}

--- a/test/randomreverser/util/MoreAssert.java
+++ b/test/randomreverser/util/MoreAssert.java
@@ -1,0 +1,17 @@
+package randomreverser.util;
+
+import org.junit.Assert;
+
+import java.math.BigDecimal;
+
+public class MoreAssert {
+
+    public static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual) {
+        assertBigDecimalEquals(expected, actual, BigDecimal.ZERO);
+    }
+
+    public static void assertBigDecimalEquals(BigDecimal expected, BigDecimal actual, BigDecimal tolerance) {
+        Assert.assertTrue(expected.subtract(actual).abs().compareTo(tolerance) <= 0);
+    }
+
+}


### PR DESCRIPTION
Noteworthy changes:
- Removed pointless factory classes in linear algebra classes.
- Renamed Matrix.width/height to columns/rows.
- Renamed vector length to dimension.
- Renamed Matrix.swap to Matrix.swapRows and Matrix.swapEquals to Matrix.swapRowsEquals.
- Renamed vector getScalarProjection to gramSchmidtCoefficient.
- Added checks for more error cases.
- Added unit tests for (nearly) all matrix and vector methods.
- Added a couple of new matrix and vector methods (along with unit tests for them).
- Fixed some failing unit tests.

Most unit tests are now passing, except for the following:
- MatrixTest.testInverseOrthogonal: kap is currently working on fixing this.
- BigMatrixTest.testInverseOrthogonal: kap is currently working on fixing this.
- BigMatrixTest.testInverseEight: inversion of 1x1 big matrices is broken.
- BigMatrixTest.testInverse5x5: BigDecimal.divide throws an exception if there is not a terminating base-10 decimal solution to the division. We need to talk about where we want the round-off to be, because this doesn't just need fixing here, it needs fixing in quite a lot of places.